### PR TITLE
!R (Logging) Refactored logging mechanism to prevent server stalls on Windows

### DIFF
--- a/FileXT/common.h
+++ b/FileXT/common.h
@@ -4,26 +4,48 @@
 
 // Configure this when building locally to enable more verbose logging.
 // By default verbose logging is enabled in debug builds.
-#define ENABLE_LOG_VERBOSE !defined(NDEBUG)
+#if !defined(NDEBUG)
+#define ENABLE_LOG_VERBOSE
+#endif
 
 // Debug logging macros
 #ifndef NDEBUG
-extern FILE* gLogFile;
-#define LOG(...) fprintf(gLogFile?gLogFile:gLogFile=stderr, __VA_ARGS__); fflush(gLogFile)
+#define LOG(...) log(__VA_ARGS__)
 #else
 #define LOG(...)
 #endif
 
-#if ENABLE_LOG_VERBOSE && !defined(NDEBUG)
-#define LOG_VERBOSE(...) fprintf(gLogFile?gLogFile:gLogFile=stderr, "FileXT: "); fprintf(gLogFile, __VA_ARGS__ ); fprintf(gLogFile, "\n"); fflush(gLogFile)
-#elif ENABLE_LOG_VERBOSE
-#define LOG_VERBOSE(...) fprintf(stderr, "FileXT: "); fprintf(stderr,  __VA_ARGS__ ); fprintf(stderr, "\n"); fflush(stderr)
+#ifdef ENABLE_LOG_VERBOSE
+#define LOG_VERBOSE(...) log("FileXT: ", __VA_ARGS__);
 #else 
 #define LOG_VERBOSE(...) 
 #endif
 
-#if !defined(NDEBUG)
-#define LOG_CRITICAL(...) fprintf(gLogFile?gLogFile:gLogFile=stderr, "FileXT: CRITICAL ERROR: "); fprintf(gLogFile, __VA_ARGS__ ); fprintf(gLogFile, "\n"); fflush(gLogFile)
+#define LOG_CRITICAL(...) logTrace(__LINE__, __FILE__, "FileXT: CRITICAL ERROR: ", __VA_ARGS__);
+
+// Forward Decls
+extern std::unique_ptr<FILE, decltype(&std::fclose)> gpFile;
+std::filesystem::path& getLogPath();
+
+template <typename ...Args>
+void log(const char* format, Args&&...args) {
+#if defined(__linux__) && !defined(NDEBUG)
+	FILE* pFile = stderr;
 #else
-#define LOG_CRITICAL(...) fprintf(stderr, "FileXT: CRITICAL ERROR: "); fprintf(stderr,  __VA_ARGS__ ); fprintf(stderr, "\n"); fflush(stderr)
+	FILE* pFile = gpFile.get();
 #endif
+
+	if (pFile != nullptr)
+	{
+		std::fprintf(pFile, format, args...);
+		std::fflush(pFile);
+	}
+}
+
+template <typename ...Args>
+inline void logTrace(int line, const char* fileName, const char* format, Args&&...args) {
+	size_t bufSize = std::snprintf(NULL, 0, "%s [%s] [line: %d]\n", format, fileName, line);
+	std::vector<char> buf(bufSize + 1, '\0');
+	std::snprintf(buf.data(), bufSize, "%s [%s] [line: %d]\n", format, fileName, line);
+	log(buf.data(), args...);
+}

--- a/FileXT/common.h
+++ b/FileXT/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdio>
+#include <vector>
 
 // Configure this when building locally to enable more verbose logging.
 // By default verbose logging is enabled in debug builds.


### PR DESCRIPTION
This change refactors the logging mechanism such that:

1. On Windows, we never write to stderr.
2. RAII added to log file handle, closing on DLL exit (static destructor).
3. For Critical Errors, source filename and line number appended to message.
4. Version text bumped to 1.2.